### PR TITLE
[SS] Add ListState implementation for State API v2.

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/ListState.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/ListState.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.streaming
+
+import org.apache.spark.annotation.{Evolving, Experimental}
+
+@Experimental
+@Evolving
+/**
+ * Interface used for arbitrary stateful operations with the v2 API to capture
+ * list value state.
+ */
+trait ListState[S] extends Serializable {
+
+  /** Whether state exists or not. */
+  def exists(): Boolean
+
+  /** Get the state value if it exists */
+  def get(): Iterator[S]
+
+  /** Get the list value as an option if it exists and None otherwise */
+  def getOption(): Option[Iterator[S]]
+
+  /** Update the value of the list. */
+  def put(newState: Seq[S]): Unit
+
+  /** Append an entry to the list */
+  def appendValue(newState: S): Unit
+
+  /** Append an entire list to the existing value */
+  def appendList(newState: Seq[S]): Unit
+
+  /** Remove this state. */
+  def remove(): Unit
+}

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
@@ -40,4 +40,10 @@ trait StatefulProcessorHandle extends Serializable {
 
   /** Function to return queryInfo for currently running task */
   def getQueryInfo(): QueryInfo
+
+  /**
+   * Creates new or returns existing list state associated with stateName.
+   * The ListState persists values of type T.
+   */
+  def getListState[T](stateName: String): ListState[T]
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ListStateImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ListStateImpl.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.streaming.state.StateStore
+import org.apache.spark.sql.streaming.ListState
+
+/**
+ * Provides concrete implementation for list of values associated with a state variable
+ * used in the streaming transformWithState operator.
+ *
+ * @param store - reference to the StateStore instance to be used for storing state
+ * @param stateName - name of logical state partition
+ * @tparam S - data type of object that will be stored in the list
+ */
+class ListStateImpl[S](store: StateStore,
+     stateName: String) extends ListState[S] with Logging {
+
+   /** Whether state exists or not. */
+   override def exists(): Boolean = {
+     val stateValue = store.get(StateEncoder.encodeGroupingKey(stateName), stateName)
+     stateValue != null
+   }
+
+   /** Get the state value if it exists. If the state does not exist in state store, an
+    * empty iterator is returned. */
+   override def get(): Iterator[S] = {
+     val encodedKey = StateEncoder.encodeGroupingKey(stateName)
+     val unsafeRowValuesIterator = store.valuesIterator(encodedKey, stateName)
+     new Iterator[S] {
+       override def hasNext: Boolean = {
+         unsafeRowValuesIterator.hasNext
+       }
+
+       override def next(): S = {
+         val valueUnsafeRow = unsafeRowValuesIterator.next()
+         StateEncoder.decodeValue(valueUnsafeRow)
+       }
+     }
+   }
+
+   /** Get the list value as an option if it exists and None otherwise. */
+   override def getOption(): Option[Iterator[S]] = {
+     Option(get())
+   }
+
+   /** Update the value of the list. */
+   override def put(newState: Seq[S]): Unit = {
+     validateNewState(newState)
+
+     if (newState.isEmpty) {
+       this.remove()
+     } else {
+       val encodedKey = StateEncoder.encodeGroupingKey(stateName)
+
+       var isFirst = true
+       newState.foreach { v =>
+         val encodedValue = StateEncoder.encodeValue(v)
+         if (isFirst) {
+           store.put(encodedKey, encodedValue, stateName)
+           isFirst = false
+         } else {
+            store.merge(encodedKey, encodedValue, stateName)
+         }
+       }
+     }
+   }
+
+   /** Append an entry to the list. */
+   override def appendValue(newState: S): Unit = {
+     if (newState == null) {
+       throw new IllegalArgumentException("value added to ListState should be non-null")
+     }
+     store.merge(StateEncoder.encodeGroupingKey(stateName),
+         StateEncoder.encodeValue(newState), stateName)
+   }
+
+   /** Append an entire list to the existing value. */
+   override def appendList(newState: Seq[S]): Unit = {
+     validateNewState(newState)
+
+     val encodedKey = StateEncoder.encodeGroupingKey(stateName)
+     newState.foreach { v =>
+       val encodedValue = StateEncoder.encodeValue(v)
+       store.merge(encodedKey, encodedValue, stateName)
+     }
+   }
+
+   /** Remove this state. */
+   override def remove(): Unit = {
+     store.remove(StateEncoder.encodeGroupingKey(stateName), stateName)
+   }
+
+   private def validateNewState(newState: Seq[S]): Unit = {
+     if (newState == null) {
+       throw new IllegalArgumentException("newState list should be non-null")
+     }
+
+     val containsNullElements = newState.contains(null)
+     if (containsNullElements) {
+       throw new IllegalArgumentException("value added to ListState should be non-null")
+     }
+   }
+ }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateEncoder.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.commons.lang3.SerializationUtils
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.types.{BinaryType, StructType}
+
+/**
+ * Helper object providing APIs to encodes the grouping key, and user provided values.
+ */
+object StateEncoder {
+
+  // TODO: validate places that are trying to encode the key and check if we can eliminate/
+  // add caching for some of these calls.
+  def encodeGroupingKey(stateName: String): UnsafeRow = {
+    val keyOption = ImplicitKeyTracker.getImplicitKeyOption
+    if (keyOption.isEmpty) {
+      throw new UnsupportedOperationException("Implicit key not found for operation on" +
+        s"stateName=$stateName")
+    }
+
+    val schemaForKeyRow: StructType = new StructType().add("key", BinaryType)
+    val keyByteArr = SerializationUtils.serialize(keyOption.get.asInstanceOf[Serializable])
+    val keyEncoder = UnsafeProjection.create(schemaForKeyRow)
+    val keyRow = keyEncoder(InternalRow(keyByteArr))
+    keyRow
+  }
+
+  def encodeValue[S] (value: S): UnsafeRow = {
+    val schemaForValueRow: StructType = new StructType().add("value", BinaryType)
+    val valueByteArr = SerializationUtils.serialize(value.asInstanceOf[Serializable])
+    val valueEncoder = UnsafeProjection.create(schemaForValueRow)
+    val valueRow = valueEncoder(InternalRow(valueByteArr))
+    valueRow
+  }
+
+  def decodeValue[S](row: UnsafeRow): S = {
+    SerializationUtils
+      .deserialize(row.getBinary(0))
+      .asInstanceOf[S]
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -161,7 +161,8 @@ case class TransformWithStateExec(
       numColsPrefixKey = 0,
       session.sqlContext.sessionState,
       Some(session.sqlContext.streams.stateStoreCoordinator),
-      useColumnFamilies = true
+      useColumnFamilies = true,
+      useStatefulProcessorEncoder = true
     ) {
       case (store: StateStore, singleIterator: Iterator[InternalRow]) =>
         val processorHandle = new StatefulProcessorHandleImpl(store, getStateInfo.queryRunId)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ValueStateImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ValueStateImpl.scala
@@ -16,16 +16,10 @@
  */
 package org.apache.spark.sql.execution.streaming
 
-import java.io.Serializable
-
-import org.apache.commons.lang3.SerializationUtils
-
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.execution.streaming.state.StateStore
 import org.apache.spark.sql.streaming.ValueState
-import org.apache.spark.sql.types._
 
 /**
  * Class that provides a concrete implementation for a single value state associated with state
@@ -38,30 +32,6 @@ class ValueStateImpl[S](
     store: StateStore,
     stateName: String) extends ValueState[S] with Logging {
 
-  // TODO: validate places that are trying to encode the key and check if we can eliminate/
-  // add caching for some of these calls.
-  private def encodeKey(): UnsafeRow = {
-    val keyOption = ImplicitKeyTracker.getImplicitKeyOption
-    if (!keyOption.isDefined) {
-      throw new UnsupportedOperationException("Implicit key not found for operation on" +
-        s"stateName=$stateName")
-    }
-
-    val schemaForKeyRow: StructType = new StructType().add("key", BinaryType)
-    val keyByteArr = SerializationUtils.serialize(keyOption.get.asInstanceOf[Serializable])
-    val keyEncoder = UnsafeProjection.create(schemaForKeyRow)
-    val keyRow = keyEncoder(InternalRow(keyByteArr))
-    keyRow
-  }
-
-  private def encodeValue(value: S): UnsafeRow = {
-    val schemaForValueRow: StructType = new StructType().add("value", BinaryType)
-    val valueByteArr = SerializationUtils.serialize(value.asInstanceOf[Serializable])
-    val valueEncoder = UnsafeProjection.create(schemaForValueRow)
-    val valueRow = valueEncoder(InternalRow(valueByteArr))
-    valueRow
-  }
-
   /** Function to check if state exists. Returns true if present and false otherwise */
   override def exists(): Boolean = {
     getImpl() != null
@@ -71,9 +41,7 @@ class ValueStateImpl[S](
   override def getOption(): Option[S] = {
     val retRow = getImpl()
     if (retRow != null) {
-      val resState = SerializationUtils
-        .deserialize(retRow.getBinary(0))
-        .asInstanceOf[S]
+      val resState = StateEncoder.decodeValue[S](retRow)
       Some(resState)
     } else {
       None
@@ -84,9 +52,7 @@ class ValueStateImpl[S](
   override def get(): S = {
     val retRow = getImpl()
     if (retRow != null) {
-      val resState = SerializationUtils
-        .deserialize(retRow.getBinary(0))
-        .asInstanceOf[S]
+      val resState = StateEncoder.decodeValue[S](retRow)
       resState
     } else {
       null.asInstanceOf[S]
@@ -94,16 +60,17 @@ class ValueStateImpl[S](
   }
 
   private def getImpl(): UnsafeRow = {
-    store.get(encodeKey(), stateName)
+    store.get(StateEncoder.encodeGroupingKey(stateName), stateName)
   }
 
   /** Function to update and overwrite state associated with given key */
   override def update(newState: S): Unit = {
-    store.put(encodeKey(), encodeValue(newState), stateName)
+    store.put(StateEncoder.encodeGroupingKey(stateName),
+      StateEncoder.encodeValue(newState), stateName)
   }
 
   /** Function to remove state for given key */
   override def remove(): Unit = {
-    store.remove(encodeKey(), stateName)
+    store.remove(StateEncoder.encodeGroupingKey(stateName), stateName)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -109,6 +109,7 @@ class RocksDB(
   }
 
   columnFamilyOptions.setCompressionType(getCompressionType(conf.compression))
+  columnFamilyOptions.setMergeOperator(new StringAppendOperator())
 
   private val dbOptions =
     new Options(new DBOptions(), columnFamilyOptions) // options to open the RocksDB
@@ -117,6 +118,7 @@ class RocksDB(
   dbOptions.setTableFormatConfig(tableFormatConfig)
   dbOptions.setMaxOpenFiles(conf.maxOpenFiles)
   dbOptions.setAllowFAllocate(conf.allowFAllocate)
+  dbOptions.setMergeOperator(new StringAppendOperator())
 
   if (conf.boundedMemoryUsage) {
     dbOptions.setWriteBufferManager(writeBufferManager)
@@ -293,6 +295,33 @@ class RocksDB(
       changelogWriter.foreach(_.put(key, value, colFamilyName))
     } else {
       changelogWriter.foreach(_.put(key, value))
+    }
+  }
+
+  def merge(key: Array[Byte], value: Array[Byte],
+            colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
+    if (useColumnFamilies) {
+      if (!checkColFamilyExists(colFamilyName)) {
+        throw new RuntimeException(s"Column family with name=$colFamilyName does not exist")
+      }
+
+      if (conf.trackTotalNumberOfRows) {
+        val oldValue = db.get(colFamilyNameToHandleMap(colFamilyName), readOptions, key)
+        if (oldValue == null) {
+          numKeysOnWritingVersion += 1
+        }
+      }
+      db.merge(colFamilyNameToHandleMap(colFamilyName), writeOptions, key, value)
+    } else {
+      if (conf.trackTotalNumberOfRows) {
+        val oldValue = db.get(readOptions, key)
+        if (oldValue == null) {
+          numKeysOnWritingVersion += 1
+        }
+      }
+      db.merge(writeOptions, key, value)
+
+      // TODO: add changelog writer support for merge operations
     }
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
@@ -17,6 +17,7 @@
 
 package org.apache.spark.sql.execution.streaming.state
 
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.{BoundReference, JoinedRow, UnsafeProjection, UnsafeRow}
 import org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider.{STATE_ENCODING_NUM_VERSION_BYTES, STATE_ENCODING_VERSION}
 import org.apache.spark.sql.types.{StructField, StructType}
@@ -29,9 +30,9 @@ sealed trait RocksDBStateEncoder {
 
   def encodeKey(row: UnsafeRow): Array[Byte]
   def encodeValue(row: UnsafeRow): Array[Byte]
-
   def decodeKey(keyBytes: Array[Byte]): UnsafeRow
   def decodeValue(valueBytes: Array[Byte]): UnsafeRow
+  def decodeValues(valueBytes: Array[Byte]): Iterator[UnsafeRow]
   def decode(byteArrayTuple: ByteArrayPair): UnsafeRowPair
 }
 
@@ -39,8 +40,11 @@ object RocksDBStateEncoder {
   def getEncoder(
       keySchema: StructType,
       valueSchema: StructType,
-      numColsPrefixKey: Int): RocksDBStateEncoder = {
-    if (numColsPrefixKey > 0) {
+      numColsPrefixKey: Int,
+      useStatefulProcessorEncoder: Boolean): RocksDBStateEncoder = {
+    if (useStatefulProcessorEncoder) {
+      new MultiValuedStateEncoder(keySchema, valueSchema)
+    } else if (numColsPrefixKey > 0) {
       new PrefixKeyScanStateEncoder(keySchema, valueSchema, numColsPrefixKey)
     } else {
       new NoPrefixKeyStateEncoder(keySchema, valueSchema)
@@ -185,6 +189,10 @@ class PrefixKeyScanStateEncoder(
   }
 
   override def supportPrefixKeyScan: Boolean = true
+
+  override def decodeValues(valueBytes: Array[Byte]): Iterator[UnsafeRow] = {
+    throw new UnsupportedOperationException("encoder does not support multiple values per key")
+  }
 }
 
 /**
@@ -248,5 +256,107 @@ class NoPrefixKeyStateEncoder(keySchema: StructType, valueSchema: StructType)
 
   override def encodePrefixKey(prefixKey: UnsafeRow): Array[Byte] = {
     throw new IllegalStateException("This encoder doesn't support prefix key!")
+  }
+
+  override def decodeValues(valueBytes: Array[Byte]): Iterator[UnsafeRow] = {
+    throw new UnsupportedOperationException("encoder does not support multiple values per key")
+  }
+}
+
+/**
+ * Supports encoding multiple values per key in RocksDB.
+ * A single value is encoded in the format below, where first value is number of bytes
+ * in actual encodedUnsafeRow followed by the encoded value itself.
+ *
+ * |---size(bytes)--|--unsafeRowEncodedBytes--|
+ *
+ * Multiple values are separated by a delimiter character.
+ *
+ * This encoder supports RocksDB StringAppendOperator merge operator. Values encoded can be
+ * merged in RocksDB using merge operation, and all merged values can be read using decodeValues
+ * operation.
+ */
+class MultiValuedStateEncoder(keySchema: StructType, valueSchema: StructType)
+  extends RocksDBStateEncoder with Logging {
+
+  import RocksDBStateEncoder._
+
+  // Reusable objects
+  private val keyRow = new UnsafeRow(keySchema.size)
+  private val valueRow = new UnsafeRow(valueSchema.size)
+  private val rowTuple = new UnsafeRowPair()
+
+  override def supportPrefixKeyScan: Boolean = false
+
+  override def encodePrefixKey(prefixKey: UnsafeRow): Array[Byte] = {
+    throw new IllegalStateException("This encoder doesn't support prefix key!")
+  }
+
+  override def extractPrefixKey(key: UnsafeRow): UnsafeRow = {
+    throw new IllegalStateException("This encoder doesn't support prefix key!")
+  }
+
+  override def encodeKey(row: UnsafeRow): Array[Byte] = {
+    encodeUnsafeRow(row)
+  }
+
+  override def encodeValue(row: UnsafeRow): Array[Byte] = {
+    val bytes = encodeUnsafeRow(row)
+    val numBytes = bytes.length
+
+    val encodedBytes = new Array[Byte](java.lang.Integer.BYTES + bytes.length)
+    Platform.putInt(encodedBytes, Platform.BYTE_ARRAY_OFFSET, numBytes)
+    Platform.copyMemory(bytes, Platform.BYTE_ARRAY_OFFSET,
+      encodedBytes, java.lang.Integer.BYTES + Platform.BYTE_ARRAY_OFFSET, bytes.length)
+
+    encodedBytes
+  }
+
+  override def decodeKey(keyBytes: Array[Byte]): UnsafeRow = {
+    decodeToUnsafeRow(keyBytes, keyRow)
+  }
+
+  override def decodeValue(valueBytes: Array[Byte]): UnsafeRow = {
+    if (valueBytes == null) {
+      null
+    } else {
+      val numBytes = Platform.getInt(valueBytes, Platform.BYTE_ARRAY_OFFSET)
+      val encodedValue = new Array[Byte](numBytes)
+      Platform.copyMemory(valueBytes, java.lang.Integer.BYTES + Platform.BYTE_ARRAY_OFFSET,
+        encodedValue, Platform.BYTE_ARRAY_OFFSET, numBytes)
+      decodeToUnsafeRow(encodedValue, valueRow)
+    }
+  }
+
+  override def decodeValues(valueBytes: Array[Byte]): Iterator[UnsafeRow] = {
+    if (valueBytes == null) {
+      Seq().iterator
+    } else {
+      new Iterator[UnsafeRow] {
+        private var pos: Int = Platform.BYTE_ARRAY_OFFSET
+        private val maxPos = Platform.BYTE_ARRAY_OFFSET + valueBytes.length
+
+        override def hasNext: Boolean = {
+          pos < maxPos
+        }
+
+        override def next(): UnsafeRow = {
+          val numBytes = Platform.getInt(valueBytes, pos)
+
+          pos += java.lang.Integer.BYTES
+          val encodedValue = new Array[Byte](numBytes)
+          Platform.copyMemory(valueBytes, pos,
+            encodedValue, Platform.BYTE_ARRAY_OFFSET, numBytes)
+
+          pos += numBytes
+          pos += 1 // eat the delimiter character
+          decodeToUnsafeRow(encodedValue, valueRow)
+        }
+      }
+    }
+  }
+
+  override def decode(byteArrayTuple: ByteArrayPair): UnsafeRowPair = {
+    rowTuple.withRows(decodeKey(byteArrayTuple.key), decodeValue(byteArrayTuple.value))
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
@@ -113,7 +113,8 @@ class StateStoreRDD[T: ClassTag, U: ClassTag](
     sessionState: SessionState,
     @transient private val storeCoordinator: Option[StateStoreCoordinatorRef],
     useColumnFamilies: Boolean = false,
-    extraOptions: Map[String, String] = Map.empty)
+    extraOptions: Map[String, String] = Map.empty,
+    useStatefulProcessorEncoder: Boolean = false)
   extends BaseStateStoreRDD[T, U](dataRDD, checkpointLocation, queryRunId, operatorId,
     sessionState, storeCoordinator, extraOptions) {
 
@@ -125,7 +126,7 @@ class StateStoreRDD[T: ClassTag, U: ClassTag](
     val inputIter = dataRDD.iterator(partition, ctxt)
     val store = StateStore.get(
       storeProviderId, keySchema, valueSchema, numColsPrefixKey, storeVersion,
-      useColumnFamilies, storeConf, hadoopConfBroadcast.value.value)
+      useColumnFamilies, storeConf, hadoopConfBroadcast.value.value, useStatefulProcessorEncoder)
     storeUpdateFunction(store, inputIter)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
@@ -57,7 +57,9 @@ package object state {
         sessionState: SessionState,
         storeCoordinator: Option[StateStoreCoordinatorRef],
         useColumnFamilies: Boolean = false,
-        extraOptions: Map[String, String] = Map.empty)(
+        extraOptions: Map[String, String] = Map.empty,
+        // TODO: refactor using the boolean parameter for choosing stateful encoder into a enum
+        useStatefulProcessorEncoder: Boolean = false)(
         storeUpdateFunction: (StateStore, Iterator[T]) => Iterator[U]): StateStoreRDD[T, U] = {
 
       val cleanedF = dataRDD.sparkContext.clean(storeUpdateFunction)
@@ -82,7 +84,8 @@ package object state {
         sessionState,
         storeCoordinator,
         useColumnFamilies,
-        extraOptions)
+        extraOptions,
+        useStatefulProcessorEncoder)
     }
 
     /** Map each partition of an RDD along with data in a [[ReadStateStore]]. */

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
@@ -55,4 +55,12 @@ class MemoryStateStore extends StateStore() {
   override def prefixScan(prefixKey: UnsafeRow, colFamilyName: String): Iterator[UnsafeRowPair] = {
     throw new UnsupportedOperationException("Doesn't support prefix scan!")
   }
+
+  override def merge(key: UnsafeRow, value: UnsafeRow, colFamilyName: String): Unit = {
+    throw new UnsupportedOperationException("store does not support multiple values per key")
+  }
+
+  override def valuesIterator(key: UnsafeRow, colFamilyName: String): Iterator[UnsafeRow] = {
+    throw new UnsupportedOperationException("store does not support multiple values per key")
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -65,7 +65,8 @@ class FakeStateStoreProviderWithMaintenanceError extends StateStoreProvider {
       numColsPrefixKey: Int,
       useColumnFamilies: Boolean,
       storeConfs: StateStoreConf,
-      hadoopConf: Configuration): Unit = {
+      hadoopConf: Configuration,
+      useStatefulProcessorEncoder: Boolean = false): Unit = {
     id = stateStoreId
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -1420,7 +1420,8 @@ class TestStateStoreProvider extends StateStoreProvider {
       numColsPrefixKey: Int,
       useColumnFamilies: Boolean,
       storeConfs: StateStoreConf,
-      hadoopConf: Configuration): Unit = {
+      hadoopConf: Configuration,
+      useStatefulProcessorEncoder: Boolean = false): Unit = {
     throw new Exception("Successfully instantiated")
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithListStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithListStateSuite.scala
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider
+import org.apache.spark.sql.internal.SQLConf
+
+case class InputRow(key: String, action: String, value: String)
+
+class TestListStateProcessor
+  extends StatefulProcessor[String, InputRow, (String, String)] {
+
+  @transient var _processorHandle: StatefulProcessorHandle = _
+  @transient var _listState: ListState[String] = _
+
+  override def init(handle: StatefulProcessorHandle, outputMode: OutputMode): Unit = {
+    _processorHandle = handle
+    _listState = handle.getListState("testListState")
+  }
+
+  override def handleInputRow(key: String,
+      row: InputRow,
+      timerValues: TimerValues): Iterator[(String, String)] = {
+
+    var output = List[(String, String)]()
+
+    if (row.action == "emit") {
+      output = (key, row.value) :: output
+    } else if (row.action == "emitAllInState") {
+      _listState.get().foreach(v => {
+        output = (key, v) :: output
+      })
+      _listState.remove()
+    } else if (row.action == "append") {
+      _listState.appendValue(row.value)
+    } else if (row.action == "appendAll") {
+      _listState.appendList(row.value.split(",").toSeq)
+    } else if (row.action == "put") {
+      _listState.put(row.value.split(",").toSeq)
+    } else if (row.action == "remove") {
+      _listState.remove()
+    } else if (row.action == "tryAppendingNull") {
+      _listState.appendValue(null)
+    } else if (row.action == "tryAppendingNullValueInList") {
+      _listState.appendList(List(null))
+    } else if (row.action == "tryAppendingNullList") {
+      _listState.appendList(null)
+    } else if (row.action == "tryPutNullList") {
+      _listState.put(null)
+    } else if (row.action == "tryPuttingNullInList") {
+      _listState.put(List(null))
+    }
+
+    output.iterator
+  }
+
+
+  override def close(): Unit = {
+  }
+}
+
+class TransformWithListStateSuite extends StreamTest {
+  import testImplicits._
+
+  test("test appending null value in list state throw exception") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+
+      val inputData = MemoryStream[InputRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestListStateProcessor(),
+          TimeoutMode.NoTimeouts(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update()) (
+        AddData(inputData, InputRow("k1", "tryAppendingNull", "")),
+        ExpectFailure[SparkException](e => {
+          assert(e.getMessage.contains("value added to ListState should be non-null"))
+        })
+      )
+    }
+  }
+
+  test("test putting null value in list state throw exception") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+
+      val inputData = MemoryStream[InputRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestListStateProcessor(),
+          TimeoutMode.NoTimeouts(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update())(
+        AddData(inputData, InputRow("k1", "tryPuttingNullInList", "")),
+        ExpectFailure[SparkException](e => {
+          assert(e.getMessage.contains("value added to ListState should be non-null"))
+        })
+      )
+    }
+  }
+
+  test("test putting null list in list state throw exception") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+
+      val inputData = MemoryStream[InputRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestListStateProcessor(),
+          TimeoutMode.NoTimeouts(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update())(
+        AddData(inputData, InputRow("k1", "tryPutNullList", "")),
+        ExpectFailure[SparkException](e => {
+          assert(e.getMessage.contains("newState list should be non-null"))
+        })
+      )
+    }
+  }
+
+  test("test appending null list in list state throw exception") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+
+      val inputData = MemoryStream[InputRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestListStateProcessor(),
+          TimeoutMode.NoTimeouts(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update())(
+        AddData(inputData, InputRow("k1", "tryAppendingNullList", "")),
+        ExpectFailure[SparkException](e => {
+          assert(e.getMessage.contains("newState list should be non-null"))
+        })
+      )
+    }
+  }
+
+  test("test list state correctness") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+
+      val inputData = MemoryStream[InputRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestListStateProcessor(),
+          TimeoutMode.NoTimeouts(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update()) (
+        // no interaction test
+        AddData(inputData, InputRow("k1", "emit", "v1")),
+        CheckNewAnswer(("k1", "v1")),
+        // check simple append
+        AddData(inputData, InputRow("k1", "append", "v2")),
+        AddData(inputData, InputRow("k1", "emitAllInState", "")),
+        CheckNewAnswer(("k1", "v2")),
+        // multiple appends are correctly stored and emitted
+        AddData(inputData, InputRow("k2", "append", "v1")),
+        AddData(inputData, InputRow("k1", "append", "v4")),
+        AddData(inputData, InputRow("k2", "append", "v2")),
+        AddData(inputData, InputRow("k1", "emit", "v5")),
+        AddData(inputData, InputRow("k2", "emit", "v3")),
+        CheckNewAnswer(("k1", "v5"), ("k2", "v3")),
+        AddData(inputData, InputRow("k1", "emitAllInState", "")),
+        AddData(inputData, InputRow("k2", "emitAllInState", "")),
+        CheckNewAnswer(("k2", "v1"), ("k2", "v2"), ("k1", "v4")),
+        // check appendAll with append
+        AddData(inputData, InputRow("k3", "appendAll", "v1,v2,v3")),
+        AddData(inputData, InputRow("k3", "emit", "v4")),
+        AddData(inputData, InputRow("k3", "append", "v5")),
+        CheckNewAnswer(("k3", "v4")),
+        AddData(inputData, InputRow("k3", "emitAllInState", "")),
+        CheckNewAnswer(("k3", "v1"), ("k3", "v2"), ("k3", "v3"), ("k3", "v5")),
+        // check removal cleans up all data in state
+        AddData(inputData, InputRow("k4", "append", "v2")),
+        AddData(inputData, InputRow("k4", "appendList", "v3,v4")),
+        AddData(inputData, InputRow("k4", "remove", "")),
+        CheckNewAnswer(),
+        // check put cleans up previous state and adds new state
+        AddData(inputData, InputRow("k5", "appendAll", "v1,v2,v3")),
+        AddData(inputData, InputRow("k5", "append", "v4")),
+        AddData(inputData, InputRow("k5", "put", "v5,v6")),
+        AddData(inputData, InputRow("k5", "emitAllInState", "")),
+        CheckNewAnswer(("k5", "v5"), ("k5", "v6"))
+      )
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR adds changes for ListState implementation in State Api v2. This implementation adds a new encoder/decoder to encode multiple values inside a single byte[] array (stored in RocksDB). The encoding scheme is compatible with RocksDB StringAppendOperator merge operator.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

These changes are needed to support list values in the State Store. The changes are part of the work around adding new stateful streaming operator for arbitrary state mgmt that provides a bunch of new features listed in the SPIP JIRA here - https://issues.apache.org/jira/browse/SPARK-45939


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes
This PR introduces a new state type (ListState) that users can use in their Spark streaming queries.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
Added a new test suite for ListState to ensure the state produces correct results. Added additional testcases for input validation. 

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
