### PR TITLE
[SS][SPIP-IN-PROGRESS][DO-NOT-MERGE] Add support for event time timers for new transformWithState operator

### DIFF
--- a/sql/api/src/main/java/org/apache/spark/sql/streaming/TimeoutMode.java
+++ b/sql/api/src/main/java/org/apache/spark/sql/streaming/TimeoutMode.java
@@ -36,6 +36,13 @@ public class TimeoutMode {
   }
 
   /**
+   * Stateful processor that only registers event time timers
+   */
+  public static final TimeoutMode EventTime() {
+    return EventTime$.MODULE$;
+  }
+
+  /**
    * Stateful processor that does not register timers
    */
   public static final TimeoutMode NoTimeouts() {

--- a/sql/api/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/TransformWithStateTimeoutModes.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/TransformWithStateTimeoutModes.scala
@@ -21,3 +21,4 @@ import org.apache.spark.sql.streaming.TimeoutMode
 /** Types of timeouts used in tranformWithState operator */
 case object NoTimeouts extends TimeoutMode
 case object ProcessingTime extends TimeoutMode
+case object EventTime extends TimeoutMode

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessor.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessor.scala
@@ -71,6 +71,22 @@ trait StatefulProcessor[K, I, O] extends Serializable {
   }
 
   /**
+   * Function that will allow users to handle event time timers for a given grouping key.
+   *
+   * @param key               - grouping key
+   * @param expiryTimestampMs - registered expiry timestamp for the timer
+   * @param timerValues  - instance of TimerValues that provides access to current processing/event
+   *                       time if available
+   * @return - Zero or more output rows
+   */
+  def handleEventTimeTimers(
+      key: K,
+      expiryTimestampMs: Long,
+      timerValues: TimerValues): Iterator[O] = {
+    Iterator.empty
+  }
+
+  /**
    * Function called as the last method that allows for users to perform
    * any cleanup or teardown operations.
    */

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
@@ -53,4 +53,19 @@ trait StatefulProcessorHandle extends Serializable {
    * @param expiryTimestampMs - timer expiry timestamp in milliseconds
    */
   def deleteProcessingTimeTimer(expiryTimestampMs: Long): Unit
+
+  /**
+   * Function to register a event time timer for given implicit key
+   *
+   * @param expiryTimestampMs - timer expiry timestamp in milliseconds
+   */
+  def registerEventTimeTimer(expiryTimestampMs: Long): Unit
+
+  /**
+   * Function to delete a event time timer for implicit key and given
+   * timestamp
+   *
+   * @param expiryTimestampMs - timer expiry timestamp in milliseconds
+   */
+  def deleteEventTimeTimer(expiryTimestampMs: Long): Unit
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -147,10 +147,13 @@ class StatefulProcessorHandleImpl(
     s"Cannot register processing time timer with " +
       s"expiryTimestampMs=$expiryTimestampMs in current state=$currState")
 
+    val queryId = getQueryInfo().getQueryId
     if (procTimers.exists(expiryTimestampMs)) {
-      logWarning(s"Processing time timer already exists for expiryTimestampMs=$expiryTimestampMs")
+      logWarning(s"Processing time timer already exists for expiryTimestampMs=$expiryTimestampMs" +
+        s" and streamingQueryId=$queryId")
     } else {
-      logInfo(s"Registering processing time timer with expiryTimestampMs=$expiryTimestampMs")
+      logInfo(s"Registering processing time timer with expiryTimestampMs=$expiryTimestampMs" +
+        s" and streamingQueryId=$queryId")
       procTimers.add(expiryTimestampMs, true)
     }
   }
@@ -162,10 +165,13 @@ class StatefulProcessorHandleImpl(
     s"Cannot delete processing time timer with " +
       s"expiryTimestampMs=$expiryTimestampMs in current state=$currState")
 
+    val queryId = getQueryInfo().getQueryId
     if (!procTimers.exists(expiryTimestampMs)) {
-      logInfo(s"Processing time timer does not exist for expiryTimestampMs=$expiryTimestampMs")
+      logInfo(s"Processing time timer does not exist for expiryTimestampMs=$expiryTimestampMs" +
+        s" and streamingQueryId=$queryId")
     } else {
-      logInfo(s"Removing processing time timer with expiryTimestampMs=$expiryTimestampMs")
+      logInfo(s"Removing processing time timer with expiryTimestampMs=$expiryTimestampMs" +
+        s" and streamingQueryId=$queryId")
       procTimers.remove(expiryTimestampMs)
     }
   }
@@ -182,10 +188,13 @@ class StatefulProcessorHandleImpl(
       s"Cannot register event time timer with " +
         s"expiryTimestampMs=$expiryTimestampMs in current state=$currState")
 
+    val queryId = getQueryInfo().getQueryId
     if (eventTimers.exists(expiryTimestampMs)) {
-      logWarning(s"Event timer already exists for expiryTimestampMs=$expiryTimestampMs")
+      logWarning(s"Event timer already exists for expiryTimestampMs=$expiryTimestampMs" +
+        s" and streamingQueryId=$queryId")
     } else {
-      logInfo(s"Registering event timer with expiryTimestampMs=$expiryTimestampMs")
+      logInfo(s"Registering event timer with expiryTimestampMs=$expiryTimestampMs" +
+        s" and streamingQueryId=$queryId")
       eventTimers.add(expiryTimestampMs, true)
     }
   }
@@ -203,10 +212,13 @@ class StatefulProcessorHandleImpl(
       s"Cannot delete event time timer with " +
         s"expiryTimestampMs=$expiryTimestampMs in current state=$currState")
 
+    val queryId = getQueryInfo().getQueryId
     if (!eventTimers.exists(expiryTimestampMs)) {
-      logInfo(s"Event time timer does not exist for expiryTimestampMs=$expiryTimestampMs")
+      logInfo(s"Event time timer does not exist for expiryTimestampMs=$expiryTimestampMs" +
+        s" and streamingQueryId=$queryId")
     } else {
-      logInfo(s"Removing event time timer with expiryTimestampMs=$expiryTimestampMs")
+      logInfo(s"Removing event time timer with expiryTimestampMs=$expiryTimestampMs" +
+        s" and streamingQueryId=$queryId")
       eventTimers.remove(expiryTimestampMs)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -148,9 +148,9 @@ class StatefulProcessorHandleImpl(
       s"expiryTimestampMs=$expiryTimestampMs in current state=$currState")
 
     if (procTimers.exists(expiryTimestampMs)) {
-      logWarning(s"Timer already exists for expiryTimestampMs=$expiryTimestampMs")
+      logWarning(s"Processing time timer already exists for expiryTimestampMs=$expiryTimestampMs")
     } else {
-      logInfo(s"Registering timer with expiryTimestampMs=$expiryTimestampMs")
+      logInfo(s"Registering processing time timer with expiryTimestampMs=$expiryTimestampMs")
       procTimers.add(expiryTimestampMs, true)
     }
   }
@@ -163,9 +163,9 @@ class StatefulProcessorHandleImpl(
       s"expiryTimestampMs=$expiryTimestampMs in current state=$currState")
 
     if (!procTimers.exists(expiryTimestampMs)) {
-      logInfo(s"Timer does not exist for expiryTimestampMs=$expiryTimestampMs")
+      logInfo(s"Processing time timer does not exist for expiryTimestampMs=$expiryTimestampMs")
     } else {
-      logInfo(s"Removing timer with expiryTimestampMs=$expiryTimestampMs")
+      logInfo(s"Removing processing time timer with expiryTimestampMs=$expiryTimestampMs")
       procTimers.remove(expiryTimestampMs)
     }
   }
@@ -183,9 +183,9 @@ class StatefulProcessorHandleImpl(
         s"expiryTimestampMs=$expiryTimestampMs in current state=$currState")
 
     if (eventTimers.exists(expiryTimestampMs)) {
-      logWarning(s"Timer already exists for expiryTimestampMs=$expiryTimestampMs")
+      logWarning(s"Event timer already exists for expiryTimestampMs=$expiryTimestampMs")
     } else {
-      logInfo(s"Registering timer with expiryTimestampMs=$expiryTimestampMs")
+      logInfo(s"Registering event timer with expiryTimestampMs=$expiryTimestampMs")
       eventTimers.add(expiryTimestampMs, true)
     }
   }
@@ -204,9 +204,9 @@ class StatefulProcessorHandleImpl(
         s"expiryTimestampMs=$expiryTimestampMs in current state=$currState")
 
     if (!eventTimers.exists(expiryTimestampMs)) {
-      logInfo(s"Timer does not exist for expiryTimestampMs=$expiryTimestampMs")
+      logInfo(s"Event time timer does not exist for expiryTimestampMs=$expiryTimestampMs")
     } else {
-      logInfo(s"Removing timer with expiryTimestampMs=$expiryTimestampMs")
+      logInfo(s"Removing event time timer with expiryTimestampMs=$expiryTimestampMs")
       eventTimers.remove(expiryTimestampMs)
     }
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TimerStateImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TimerStateImpl.scala
@@ -35,6 +35,7 @@ object TimerStateUtils {
       expiryTimestampMs: Long) extends Serializable
 
   val PROC_TIMERS_STATE_NAME = "_procTimers"
+  val EVENT_TIMERS_STATE_NAME = "_eventTimers"
 }
 
 /**

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -184,7 +184,7 @@ case class TransformWithStateExec(
           handleTimerRows(store, rowPair.key, batchTimestampMs.get)
         }
       case EventTime =>
-        assert(batchTimestampMs.isDefined)
+        assert(eventTimeWatermarkForEviction.isDefined)
         store.createColFamilyIfAbsent(TimerStateUtils.EVENT_TIMERS_STATE_NAME, true)
 
         val eventTimeIter = store

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -113,7 +113,7 @@ case class TransformWithStateExec(
           case ProcessingTime =>
             val mi = statefulProcessor.handleProcessingTimeTimers(tsWithKey.key,
               tsWithKey.expiryTimestampMs,
-              new TimerValuesImpl(batchTimestampMs, eventTimeWatermarkForLateEvents)).map {
+              new TimerValuesImpl(batchTimestampMs, eventTimeWatermarkForEviction)).map {
               obj =>
                 getOutputRow(obj)
             }
@@ -123,8 +123,7 @@ case class TransformWithStateExec(
           case EventTime =>
             val mi = statefulProcessor.handleEventTimeTimers(tsWithKey.key,
               tsWithKey.expiryTimestampMs,
-              new TimerValuesImpl(eventTimeWatermarkForEviction,
-                eventTimeWatermarkForLateEvents)).map {
+              new TimerValuesImpl(batchTimestampMs, eventTimeWatermarkForEviction)).map {
               obj =>
                 getOutputRow(obj)
             }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -70,7 +70,8 @@ case class TransformWithStateExec(
       // TODO: check if we can return true only if actual timers are registered
       case ProcessingTime =>
         true
-
+      case EventTime =>
+        true
       case _ =>
         false
     }
@@ -105,13 +106,30 @@ case class TransformWithStateExec(
 
     if (tsWithKey.expiryTimestampMs < currTimestampMs) {
       ImplicitKeyTracker.setImplicitKey(tsWithKey.key)
-      val mappedIterator = statefulProcessor.handleProcessingTimeTimers(tsWithKey.key,
-        tsWithKey.expiryTimestampMs,
-        new TimerValuesImpl(batchTimestampMs, eventTimeWatermarkForLateEvents)).map { obj =>
-        getOutputRow(obj)
-      }
-      ImplicitKeyTracker.removeImplicitKey()
-      store.remove(keyRow, TimerStateUtils.PROC_TIMERS_STATE_NAME)
+
+      val mappedIterator =
+        timeoutMode match {
+          case ProcessingTime =>
+            val mi = statefulProcessor.handleProcessingTimeTimers(tsWithKey.key,
+              tsWithKey.expiryTimestampMs,
+              new TimerValuesImpl(batchTimestampMs, eventTimeWatermarkForLateEvents)).map {
+              obj =>
+                getOutputRow(obj)
+            }
+            ImplicitKeyTracker.removeImplicitKey()
+            store.remove(keyRow, TimerStateUtils.PROC_TIMERS_STATE_NAME)
+            mi
+          case EventTime =>
+            val mi = statefulProcessor.handleEventTimeTimers(tsWithKey.key,
+              tsWithKey.expiryTimestampMs,
+              new TimerValuesImpl(batchTimestampMs, eventTimeWatermarkForLateEvents)).map {
+              obj =>
+                getOutputRow(obj)
+            }
+            ImplicitKeyTracker.removeImplicitKey()
+            store.remove(keyRow, TimerStateUtils.EVENT_TIMERS_STATE_NAME)
+            mi
+        }
       mappedIterator
     } else {
       Iterator.empty
@@ -163,7 +181,15 @@ case class TransformWithStateExec(
         procTimeIter.flatMap { case rowPair =>
           handleTimerRows(store, rowPair.key, batchTimestampMs.get)
         }
+      case EventTime =>
+        assert(batchTimestampMs.isDefined)
+        store.createColFamilyIfAbsent(TimerStateUtils.EVENT_TIMERS_STATE_NAME, true)
 
+        val eventTimeIter = store
+          .iterator(TimerStateUtils.EVENT_TIMERS_STATE_NAME)
+        eventTimeIter.flatMap { case rowPair =>
+          handleTimerRows(store, rowPair.key, batchTimestampMs.get)
+        }
       case _ => Iterator.empty
     }
   }
@@ -238,6 +264,8 @@ case class TransformWithStateExec(
 
     timeoutMode match {
       case ProcessingTime =>
+        require(batchTimestampMs.nonEmpty)
+      case EventTime =>
         require(batchTimestampMs.nonEmpty)
 
       case _ =>

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDB.scala
@@ -213,7 +213,8 @@ class RocksDB(
    * @return - true if the column family is for internal use, false otherwise
    */
   private def checkInternalColumnFamilies(cfName: String): Boolean = {
-    if (cfName == TimerStateUtils.PROC_TIMERS_STATE_NAME) {
+    if (cfName == TimerStateUtils.PROC_TIMERS_STATE_NAME
+      || cfName == TimerStateUtils.EVENT_TIMERS_STATE_NAME) {
       true
     } else {
       false

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StatefulProcessorHandleSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StatefulProcessorHandleSuite.scala
@@ -60,10 +60,10 @@ class StatefulProcessorHandleSuite extends SharedSparkSession
   val schemaForValueRow: StructType = new StructType().add("value", BinaryType)
 
   private def newStoreProviderWithHandle(useColumnFamilies: Boolean):
-  RocksDBStateStoreProvider = {
-    newStoreProviderWithHandle(StateStoreId(newDir(), Random.nextInt(), 0),
-      numColsPrefixKey = 0,
-      useColumnFamilies = useColumnFamilies)
+    RocksDBStateStoreProvider = {
+      newStoreProviderWithHandle(StateStoreId(newDir(), Random.nextInt(), 0),
+        numColsPrefixKey = 0,
+        useColumnFamilies = useColumnFamilies)
   }
 
   private def newStoreProviderWithHandle(

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/EventTimeWatermarkSuite.scala
@@ -998,6 +998,13 @@ class EventTimeWatermarkSuite extends StreamTest with BeforeAndAfter with Matche
     }
   }
 
+  /** Assert event stats generated on that last batch with data in it */
+  def assertWatermark(wtrmark: Long): AssertOnQuery = {
+    assertEventStats { e =>
+      assert(e.get("watermark") === formatTimestamp(wtrmark), s"watermark value mismatch")
+    }
+  }
+
   private val timestampFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'") // ISO8601
   timestampFormat.setTimeZone(ju.TimeZone.getTimeZone(UTC))
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -138,6 +138,81 @@ class RunningCountStatefulProcessorWithAddRemoveProcTimeTimer
   }
 }
 
+// Class to verify stateful processor usage with adding event time timers
+class RunningCountStatefulProcessorWithEventTimeTimer extends RunningCountStatefulProcessor {
+  override def handleInputRows(
+      key: String,
+      inputRows: Iterator[String],
+      timerValues: TimerValues): Iterator[(String, String)] = {
+    val currCount = _countState.getOption().getOrElse(0L)
+    if (currCount == 0 && (key == "a" || key == "c")) {
+      _processorHandle.registerEventTimeTimer(timerValues.getCurrentProcessingTimeInMs()
+        + 5000)
+    }
+
+    val count = currCount + inputRows.size
+    if (count == 3) {
+      _countState.remove()
+      Iterator.empty
+    } else {
+      _countState.update(count)
+      Iterator((key, count.toString))
+    }
+  }
+
+  override def handleEventTimeTimers(
+     key: String,
+     expiryTimestampMs: Long,
+     timerValues: TimerValues): Iterator[(String, String)] = {
+    _countState.remove()
+    Iterator((key, "-1"))
+  }
+}
+
+// Class to verify stateful processor usage with adding/deleting processing time timers
+class RunningCountStatefulProcessorWithAddRemoveEventTimeTimer
+  extends RunningCountStatefulProcessor {
+  @transient private var _timerState: ValueState[Long] = _
+
+  override def init(
+     handle: StatefulProcessorHandle,
+     outputMode: OutputMode) : Unit = {
+    super.init(handle, outputMode)
+    _timerState = _processorHandle.getValueState[Long]("timerState")
+  }
+
+  override def handleInputRows(
+      key: String,
+      inputRows: Iterator[String],
+      timerValues: TimerValues): Iterator[(String, String)] = {
+    val currCount = _countState.getOption().getOrElse(0L)
+    val count = currCount + inputRows.size
+    _countState.update(count)
+    if (key == "a") {
+      var nextTimerTs: Long = 0L
+      if (currCount == 0) {
+        nextTimerTs = timerValues.getCurrentWatermarkInMs() + 5000
+        _processorHandle.registerEventTimeTimer(nextTimerTs)
+        _timerState.update(nextTimerTs)
+      } else if (currCount == 1) {
+        _processorHandle.deleteEventTimeTimer(_timerState.get())
+        nextTimerTs = timerValues.getCurrentWatermarkInMs() + 7500
+        _processorHandle.registerEventTimeTimer(nextTimerTs)
+        _timerState.update(nextTimerTs)
+      }
+    }
+    Iterator((key, count.toString))
+  }
+
+  override def handleEventTimeTimers(
+     key: String,
+     expiryTimestampMs: Long,
+     timerValues: TimerValues): Iterator[(String, String)] = {
+    _timerState.remove()
+    Iterator((key, "-1"))
+  }
+}
+
 // Class to verify incorrect usage of stateful processor
 class RunningCountStatefulProcessorWithError extends RunningCountStatefulProcessor {
   @transient private var _tempState: ValueState[Long] = _
@@ -264,6 +339,81 @@ class TransformWithStateSuite extends StateStoreMetricsTest
         .transformWithState(
           new RunningCountStatefulProcessorWithAddRemoveProcTimeTimer(),
           TimeoutMode.ProcessingTime(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update())(
+        StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock),
+        AddData(inputData, "a"),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(("a", "1")),
+
+        AddData(inputData, "a"),
+        AdvanceManualClock(2 * 1000),
+        CheckNewAnswer(("a", "2")),
+        StopStream,
+
+        StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock),
+        AddData(inputData, "d"),
+        AdvanceManualClock(10 * 1000),
+        CheckNewAnswer(("a", "-1"), ("d", "1")),
+        StopStream
+      )
+    }
+  }
+
+  test("transformWithState - streaming with rocksdb and event time timer " +
+    "should succeed") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+      val clock = new StreamManualClock
+
+      val inputData = MemoryStream[String]
+      val result = inputData.toDS()
+        .groupByKey(x => x)
+        .transformWithState(new RunningCountStatefulProcessorWithEventTimeTimer(),
+          TimeoutMode.EventTime(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update())(
+        StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock),
+        AddData(inputData, "a"),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(("a", "1")),
+
+        AddData(inputData, "b"),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(("b", "1")),
+
+        AddData(inputData, "b"),
+        AdvanceManualClock(10 * 1000),
+        CheckNewAnswer(("a", "-1"), ("b", "2")),
+
+        StopStream,
+        StartStream(Trigger.ProcessingTime("1 second"), triggerClock = clock),
+        AddData(inputData, "b"),
+        AddData(inputData, "c"),
+        AdvanceManualClock(1 * 1000),
+        CheckNewAnswer(("c", "1")),
+        AddData(inputData, "d"),
+        AdvanceManualClock(10 * 1000),
+        CheckNewAnswer(("c", "-1"), ("d", "1")),
+        StopStream
+      )
+    }
+  }
+
+  test("transformWithState - streaming with rocksdb and event time timer " +
+    "and add/remove timers should succeed") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+      val clock = new StreamManualClock
+
+      val inputData = MemoryStream[String]
+      val result = inputData.toDS()
+        .groupByKey(x => x)
+        .transformWithState(
+          new RunningCountStatefulProcessorWithAddRemoveEventTimeTimer(),
+          TimeoutMode.EventTime(),
           OutputMode.Update())
 
       testStream(result, OutputMode.Update())(

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.{AnalysisException, SaveMode}
 import org.apache.spark.sql.execution.streaming._
-import org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider
+import org.apache.spark.sql.execution.streaming.state.{AlsoTestWithChangelogCheckpointingEnabled, RocksDBStateStoreProvider}
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.streaming.util.StreamManualClock
 
@@ -247,7 +247,8 @@ class RunningCountStatefulProcessorWithError extends RunningCountStatefulProcess
 /**
  * Class that adds tests for transformWithState stateful streaming operator
  */
-class TransformWithStateSuite extends StateStoreMetricsTest {
+class TransformWithStateSuite extends StateStoreMetricsTest
+  with AlsoTestWithChangelogCheckpointingEnabled {
 
   import testImplicits._
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithStateSuite.scala
@@ -433,7 +433,6 @@ class TransformWithStateSuite extends StateStoreMetricsTest
           TimeoutMode.EventTime(),
           OutputMode.Update())
 
-
       testStream(result, OutputMode.Update())(
         StartStream(),
         AddData(inputData, ("a", Timestamp.valueOf("2023-08-01 00:00:00"))),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add support for event time timers for new transformWithState operator

### Why are the changes needed?
With this change, users can now specify the `TimeoutMode` as `EventTime` and register event time timers within the `StatefulProcessor` used with the `TransformWithState` operator.

Timers implement the following properties:
1. Timers are de-duplicated (only 1 timer per key + expiry timestamp is allowed and others are ignored)
2. Timers can be added and removed
3. Timers are checkpointed as part of the state since they are themselves stored as special (internal) column families

### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Added new unit tests

```
StatefulProcessorHandleSuite
...
[info] Run completed in 3 seconds, 771 milliseconds.
[info] Total number of tests run: 11
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 11, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 30 s, completed Jan 3, 2024, 8:54:52 AM

TransformWithStateSuite
...
[info] Run completed in 57 seconds, 68 milliseconds.
[info] Total number of tests run: 12
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 12, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 66 s (01:06), completed Jan 3, 2024, 8:56:10 AM
```


### Was this patch authored or co-authored using generative AI tooling?
No
