### PR TITLE
[DRAFT][DO NOT MERGE] MapState - StateStore.iterator() not working

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/ListState.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/ListState.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.streaming
+
+import org.apache.spark.annotation.{Evolving, Experimental}
+
+@Experimental
+@Evolving
+/**
+ * Interface used for arbitrary stateful operations with the v2 API to capture
+ * list value state.
+ */
+trait ListState[S] extends Serializable {
+
+  /** Whether state exists or not. */
+  def exists(): Boolean
+
+  /** Get the state value if it exists */
+  def get(): Iterator[S]
+
+  /** Get the list value as an option if it exists and None otherwise */
+  def getOption(): Option[Iterator[S]]
+
+  /** Update the value of the list. */
+  def put(newState: Seq[S]): Unit
+
+  /** Append an entry to the list */
+  def appendValue(newState: S): Unit
+
+  /** Append an entire list to the existing value */
+  def appendList(newState: Seq[S]): Unit
+
+  /** Remove this state. */
+  def remove(): Unit
+}

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/MapState.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/MapState.scala
@@ -38,10 +38,10 @@ trait MapState[K, V] extends Serializable {
   /** Update value for given user key */
   def updateValue(key: K, value: V) : Unit
 
-  /** Get the map associated with grouping key
+  /** Get the map associated with grouping key */
   def getMap(): Map[K, V]
 
-  /** Get the list of keys present in map associated with grouping key */
+  /* Get the list of keys present in map associated with grouping key
   def getKeys(): Iterator[K]
 
   /** Get the list of values present in map associated with grouping key */

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/MapState.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/MapState.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.streaming
+
+import org.apache.spark.annotation.{Evolving, Experimental}
+
+@Experimental
+@Evolving
+/**
+ * Interface used for arbitrary stateful operations with the v2 API to capture
+ * map value state.
+ */
+trait MapState[K, V] extends Serializable {
+
+  /** Whether state exists or not. */
+  def exists(): Boolean
+
+  /** Get the state value if it exists */
+  def getValue(key: K): V
+
+  /** Check if the user key is contained in the map */
+  def containsKey(key: K): Boolean
+
+  /** Update value for given user key */
+  def updateValue(key: K, value: V) : Unit
+
+  /** Get the map associated with grouping key */
+  def getMap(): Map[K, V]
+
+  /** Get the list of keys present in map associated with grouping key */
+  def getKeys(): Iterator[K]
+
+  /** Get the list of values present in map associated with grouping key */
+  def getValues(): Iterator[V]
+
+  /** Remove user key from map state */
+  def removeKey(key: K): Unit
+
+  /** Remove this state. */
+  def remove(): Unit
+}
+

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/MapState.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/MapState.scala
@@ -38,7 +38,7 @@ trait MapState[K, V] extends Serializable {
   /** Update value for given user key */
   def updateValue(key: K, value: V) : Unit
 
-  /** Get the map associated with grouping key */
+  /** Get the map associated with grouping key
   def getMap(): Map[K, V]
 
   /** Get the list of keys present in map associated with grouping key */
@@ -51,6 +51,6 @@ trait MapState[K, V] extends Serializable {
   def removeKey(key: K): Unit
 
   /** Remove this state. */
-  def remove(): Unit
+  def remove(): Unit */
 }
 

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
@@ -40,4 +40,10 @@ trait StatefulProcessorHandle extends Serializable {
 
   /** Function to return queryInfo for currently running task */
   def getQueryInfo(): QueryInfo
+
+  /**
+   * Creates new or returns existing list state associated with stateName.
+   * The ListState persists values of type T.
+   */
+  def getListState[T](stateName: String): ListState[T]
 }

--- a/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/streaming/StatefulProcessorHandle.scala
@@ -46,4 +46,6 @@ trait StatefulProcessorHandle extends Serializable {
    * The ListState persists values of type T.
    */
   def getListState[T](stateName: String): ListState[T]
+
+  def getMapState[K, V](stateName: String): MapState[K, V]
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ListStateImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/ListStateImpl.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.streaming.state.StateStore
+import org.apache.spark.sql.streaming.ListState
+
+/**
+ * Provides concrete implementation for list of values associated with a state variable
+ * used in the streaming transformWithState operator.
+ *
+ * @param store - reference to the StateStore instance to be used for storing state
+ * @param stateName - name of logical state partition
+ * @tparam S - data type of object that will be stored in the list
+ */
+class ListStateImpl[S](store: StateStore,
+     stateName: String) extends ListState[S] with Logging {
+
+   /** Whether state exists or not. */
+   override def exists(): Boolean = {
+     val stateValue = store.get(StateEncoder.encodeKey(stateName), stateName)
+     stateValue != null
+   }
+
+   /** Get the state value if it exists. If the state does not exist in state store, an
+    * empty iterator is returned. */
+   override def get(): Iterator[S] = {
+     val encodedKey = StateEncoder.encodeKey(stateName)
+     val unsafeRowValuesIterator = store.valuesIterator(encodedKey, stateName)
+     new Iterator[S] {
+       override def hasNext: Boolean = {
+         unsafeRowValuesIterator.hasNext
+       }
+
+       override def next(): S = {
+         val valueUnsafeRow = unsafeRowValuesIterator.next()
+         StateEncoder.decode(valueUnsafeRow)
+       }
+     }
+   }
+
+   /** Get the list value as an option if it exists and None otherwise. */
+   override def getOption(): Option[Iterator[S]] = {
+     Option(get())
+   }
+
+   /** Update the value of the list. */
+   override def put(newState: Seq[S]): Unit = {
+     validateNewState(newState)
+
+     if (newState.isEmpty) {
+       this.remove()
+     } else {
+       val encodedKey = StateEncoder.encodeKey(stateName)
+
+       var isFirst = true
+       newState.foreach { v =>
+         val encodedValue = StateEncoder.encodeValue(v)
+         if (isFirst) {
+           store.put(encodedKey, encodedValue, stateName)
+           isFirst = false
+         } else {
+            store.merge(encodedKey, encodedValue, stateName)
+         }
+       }
+     }
+   }
+
+   /** Append an entry to the list. */
+   override def appendValue(newState: S): Unit = {
+     if (newState == null) {
+       throw new IllegalArgumentException("value added to ListState should be non-null")
+     }
+     store.merge(StateEncoder.encodeKey(stateName),
+         StateEncoder.encodeValue(newState), stateName)
+   }
+
+   /** Append an entire list to the existing value. */
+   override def appendList(newState: Seq[S]): Unit = {
+     validateNewState(newState)
+
+     val encodedKey = StateEncoder.encodeKey(stateName)
+     newState.foreach { v =>
+       val encodedValue = StateEncoder.encodeValue(v)
+       store.merge(encodedKey, encodedValue, stateName)
+     }
+   }
+
+   /** Remove this state. */
+   override def remove(): Unit = {
+     store.remove(StateEncoder.encodeKey(stateName), stateName)
+   }
+
+   private def validateNewState(newState: Seq[S]): Unit = {
+     if (newState == null) {
+       throw new IllegalArgumentException("newState list should be non-null")
+     }
+
+     val containsNullElements = newState.contains(null)
+     if (containsNullElements) {
+       throw new IllegalArgumentException("value added to ListState should be non-null")
+     }
+   }
+ }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MapStateImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/MapStateImpl.scala
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.streaming.state.StateStore
+import org.apache.spark.sql.streaming.MapState
+
+class MapStateImpl[K, V](store: StateStore,
+                         stateName: String) extends MapState[K, V] with Logging {
+  /** Whether state exists or not. */
+  override def exists(): Boolean = {
+    true
+  }
+
+  /** Get the state value if it exists */
+  override def getValue(key: K): V = {
+    val encodedGroupingKey = StateEncoder.encodeKey(stateName) // unsafe rows of grouping key
+    val encodeUserKey = StateEncoder.encodeUserKey(key)
+    println(s"I am inside getValue: userkey: $encodeUserKey")
+    val unsafeRowValue = store.get(encodedGroupingKey, encodeUserKey, stateName)
+    if (unsafeRowValue == null) {
+      throw new UnsupportedOperationException("Cannot get value on empty key")
+    }
+    StateEncoder.decode(unsafeRowValue)
+  }
+
+  /** Check if the user key is contained in the map */
+  override def containsKey(key: K): Boolean = {
+    try {
+      println(s"I am inside containsKey: ${getValue(key)}")
+      getValue(key) != null
+    } catch {
+      case e: Exception => false
+    }
+  }
+
+  /** Update value for given user key */
+  override def updateValue(key: K, value: V): Unit = {
+    val encodedValue = StateEncoder.encodeValue(value)
+    val encodedKey = StateEncoder.encodeKey(stateName)
+    val encodedUserKey = StateEncoder.encodeUserKey(key)
+    println(s"Hey I am actually inside updateValue: userKey: $key value: $value")
+    println(s"I am inside updateValue, encoded row userKey: $encodedUserKey")
+    store.putWithMultipleKeys(encodedKey, encodedUserKey, encodedValue, stateName)
+  }
+
+  /* Get the map associated with grouping key
+  override def getMap(): Map[K, V] = {
+
+  }
+
+  /** Get the list of keys present in map associated with grouping key */
+  override def getKeys(): Iterator[K] = {}
+
+  /** Get the list of values present in map associated with grouping key */
+  override def getValues(): Iterator[V] = {}
+
+  /** Remove user key from map state */
+  override def removeKey(key: K): Unit = {}
+
+  /** Remove this state. */
+  override def remove(): Unit = {} */
+}
+
+

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateEncoder.scala
@@ -41,6 +41,14 @@ object StateEncoder {
     keyRow
   }
 
+  def encodeUserKey[K](userKey: K): UnsafeRow = {
+    val schemaForKeyRow: StructType = new StructType().add("userKey", BinaryType)
+    val keyByteArr = SerializationUtils.serialize(userKey.asInstanceOf[Serializable])
+    val keyEncoder = UnsafeProjection.create(schemaForKeyRow)
+    val keyRow = keyEncoder(InternalRow(keyByteArr))
+    keyRow
+  }
+
   def encodeValue[S] (value: S): UnsafeRow = {
     val schemaForValueRow: StructType = new StructType().add("value", BinaryType)
     val valueByteArr = SerializationUtils.serialize(value.asInstanceOf[Serializable])

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StateEncoder.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.streaming
+
+import org.apache.commons.lang3.SerializationUtils
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{UnsafeProjection, UnsafeRow}
+import org.apache.spark.sql.types.{BinaryType, StructType}
+
+object StateEncoder {
+
+  // TODO: validate places that are trying to encode the key and check if we can eliminate/
+  // add caching for some of these calls.
+  def encodeKey(stateName: String): UnsafeRow = {
+    val keyOption = ImplicitKeyTracker.getImplicitKeyOption
+    if (keyOption.isEmpty) {
+      throw new UnsupportedOperationException("Implicit key not found for operation on" +
+        s"stateName=$stateName")
+    }
+
+    val schemaForKeyRow: StructType = new StructType().add("key", BinaryType)
+    val keyByteArr = SerializationUtils.serialize(keyOption.get.asInstanceOf[Serializable])
+    val keyEncoder = UnsafeProjection.create(schemaForKeyRow)
+    val keyRow = keyEncoder(InternalRow(keyByteArr))
+    keyRow
+  }
+
+  def encodeValue[S] (value: S): UnsafeRow = {
+    val schemaForValueRow: StructType = new StructType().add("value", BinaryType)
+    val valueByteArr = SerializationUtils.serialize(value.asInstanceOf[Serializable])
+    val valueEncoder = UnsafeProjection.create(schemaForValueRow)
+    val valueRow = valueEncoder(InternalRow(valueByteArr))
+    valueRow
+  }
+
+  def decode[S](row: UnsafeRow): S = {
+    SerializationUtils
+      .deserialize(row.getBinary(0))
+      .asInstanceOf[S]
+  }
+}

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/StatefulProcessorHandleImpl.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 import org.apache.spark.TaskContext
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.streaming.state.StateStore
-import org.apache.spark.sql.streaming.{ListState, QueryInfo, StatefulProcessorHandle, ValueState}
+import org.apache.spark.sql.streaming.{ListState, MapState, QueryInfo, StatefulProcessorHandle, ValueState}
 import org.apache.spark.util.Utils
 
 /**
@@ -131,6 +131,14 @@ class StatefulProcessorHandleImpl(store: StateStore, runId: UUID)
       "initialization is complete")
     store.createColFamilyIfAbsent(stateName)
     val resultState = new ListStateImpl[T](store, stateName)
+    resultState
+  }
+
+  override def getMapState[K, V](stateName: String): MapState[K, V] = {
+    verify(currState == CREATED, s"Cannot create state variable with name=$stateName after " +
+      "initialization is complete")
+    store.createColFamilyIfAbsent(stateName)
+    val resultState = new MapStateImpl[K, V](store, stateName)
     resultState
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/TransformWithStateExec.scala
@@ -159,7 +159,8 @@ case class TransformWithStateExec(
       numColsPrefixKey = 0,
       session.sqlContext.sessionState,
       Some(session.sqlContext.streams.stateStoreCoordinator),
-      useColumnFamilies = true
+      useColumnFamilies = true,
+      useStatefulProcessorEncoder = true
     ) {
       case (store: StateStore, singleIterator: Iterator[InternalRow]) =>
         val processorHandle = new StatefulProcessorHandleImpl(store, getStateInfo.queryRunId)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/HDFSBackedStateStoreProvider.scala
@@ -84,6 +84,10 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
       map.iterator()
     }
 
+    override def get(key: UnsafeRow, userKey: UnsafeRow, colFamilyName: String): UnsafeRow = {
+      throw new UnsupportedOperationException("Multiple keys get is not supported for HDFS")
+    }
+
     override def abort(): Unit = {}
 
     override def toString(): String = {
@@ -125,6 +129,15 @@ private[sql] class HDFSBackedStateStoreProvider extends StateStoreProvider with 
 
     override def get(key: UnsafeRow, colFamilyName: String): UnsafeRow = {
       mapToUpdate.get(key)
+    }
+
+    override def get(key: UnsafeRow, userKey: UnsafeRow, colFamilyName: String): UnsafeRow = {
+      throw new UnsupportedOperationException("Multiple keys get is not supported for HDFS")
+    }
+
+    override def putWithMultipleKeys(key: UnsafeRow, userKey: UnsafeRow, value: UnsafeRow,
+                            colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
+      throw new UnsupportedOperationException("Multiple keys put is not supported for HDFS")
     }
 
     override def put(key: UnsafeRow, value: UnsafeRow, colFamilyName: String): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateEncoder.scala
@@ -317,7 +317,6 @@ class StatefulProcessorStateEncoder(keySchema: StructType, valueSchema: StructTy
     Platform.copyMemory(remainingEncoded, Platform.BYTE_ARRAY_OFFSET,
       encodedBytes, Platform.BYTE_ARRAY_OFFSET + 4 + prefixKeyEncoded.length,
       remainingEncoded.length)
-    // println(s"I am inside encodeKeys: $encodedBytes")
     encodedBytes
   }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/RocksDBStateStoreProvider.scala
@@ -25,6 +25,7 @@ import org.apache.spark.{SparkConf, SparkEnv}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow
 import org.apache.spark.sql.errors.QueryExecutionErrors
+import org.apache.spark.sql.execution.streaming.StateEncoder
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.util.Utils
 
@@ -54,7 +55,23 @@ private[sql] class RocksDBStateStoreProvider
 
     override def get(key: UnsafeRow, colFamilyName: String): UnsafeRow = {
       verify(key != null, "Key cannot be null")
+      println(s"i am inside get, encoded key row: ")
+      printArrayContents(encoder.encodeKey(key))
       val value = encoder.decodeValue(rocksDB.get(encoder.encodeKey(key), colFamilyName))
+      if (!isValidated && value != null) {
+        StateStoreProvider.validateStateRowFormat(
+          key, keySchema, value, valueSchema, storeConf)
+        isValidated = true
+      }
+      value
+    }
+
+    override def get(key: UnsafeRow, userKey: UnsafeRow, colFamilyName: String): UnsafeRow = {
+      verify(key != null, "Key cannot be null")
+      val encodedCompositeKey = encoder.encodeKey(key)
+      println(s"I am inside multiple key get, key row: $key, userkey row: $userKey")
+      println("I am inside multiple key get, decoded user key: " + StateEncoder.decode(userKey))
+      val value = encoder.decodeValue(rocksDB.get(encoder.encodeKeys(key, userKey), colFamilyName))
       if (!isValidated && value != null) {
         StateStoreProvider.validateStateRowFormat(
           key, keySchema, value, valueSchema, storeConf)
@@ -65,6 +82,8 @@ private[sql] class RocksDBStateStoreProvider
 
     override def valuesIterator(key: UnsafeRow, colFamilyName: String): Iterator[UnsafeRow] = {
       verify(key != null, "Key cannot be null")
+      print(s"inside valuesIterator, row key: ${key}, encoded key: ")
+      printArrayContents(encoder.encodeKey(key))
       val valueIterator = encoder.decodeValues(rocksDB.get(encoder.encodeKey(key), colFamilyName))
 
       if (!isValidated && valueIterator.nonEmpty) {
@@ -89,11 +108,19 @@ private[sql] class RocksDBStateStoreProvider
       }
     }
 
+    def printArrayContents(arr: Array[Byte]): Unit = {
+      arr.foreach(byteValue => print(s"$byteValue "))
+      // Add a newline after printing the array elements for better readability
+      println()
+    }
+
     override def merge(key: UnsafeRow, value: UnsafeRow,
                        colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
       verify(state == UPDATING, "Cannot put after already committed or aborted")
       verify(key != null, "Key cannot be null")
       require(value != null, "Cannot put a null value")
+      print(s"inside merge, row key: $key, encoded key: ")
+      printArrayContents(encoder.encodeKey(key))
       rocksDB.merge(encoder.encodeKey(key), encoder.encodeValue(value), colFamilyName)
     }
 
@@ -101,7 +128,19 @@ private[sql] class RocksDBStateStoreProvider
       verify(state == UPDATING, "Cannot put after already committed or aborted")
       verify(key != null, "Key cannot be null")
       require(value != null, "Cannot put a null value")
+      print(s"i am inside put, encoded key row: ")
+      printArrayContents(encoder.encodeKey(key))
       rocksDB.put(encoder.encodeKey(key), encoder.encodeValue(value), colFamilyName)
+    }
+
+    override def putWithMultipleKeys(key: UnsafeRow, userKey: UnsafeRow, value: UnsafeRow,
+                     colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
+      verify(state == UPDATING, "Cannot put after already committed or aborted")
+      verify(key != null, "Key cannot be null")
+      require(value != null, "Cannot put a null value")
+      println(s"I am inside putMultipleKeys: key: $key userKey: $userKey value: $value")
+      println(s"decoded userkey inside multiple key: ${StateEncoder.decode(userKey)}")
+      rocksDB.put(encoder.encodeKeys(key, userKey), encoder.encodeValue(value), colFamilyName)
     }
 
     override def remove(key: UnsafeRow, colFamilyName: String): Unit = {

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStore.scala
@@ -67,6 +67,8 @@ trait ReadStateStore {
   def get(key: UnsafeRow,
     colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): UnsafeRow
 
+  def get(key: UnsafeRow, userKey: UnsafeRow, colFamilyName: String): UnsafeRow
+
   /**
    * Provides an iterator on values for a particular key. The values are merged together
    * and stored as a byte Array in the underlying state store. This operation relies
@@ -123,6 +125,9 @@ trait StateStore extends ReadStateStore {
   def put(key: UnsafeRow, value: UnsafeRow,
     colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit
 
+  def putWithMultipleKeys(key: UnsafeRow, userKey: UnsafeRow, value: UnsafeRow,
+          colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit
+
   /**
    * Remove a single non-null key.
    */
@@ -174,6 +179,9 @@ class WrappedReadStateStore(store: StateStore) extends ReadStateStore {
   override def get(key: UnsafeRow,
     colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): UnsafeRow = store.get(key,
     colFamilyName)
+
+  override def get(key: UnsafeRow, userKey: UnsafeRow, colFamilyName: String): UnsafeRow =
+    store.get(key, userKey, colFamilyName)
 
   override def iterator(colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME):
     Iterator[UnsafeRowPair] = store.iterator(colFamilyName)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/StateStoreRDD.scala
@@ -113,7 +113,8 @@ class StateStoreRDD[T: ClassTag, U: ClassTag](
     sessionState: SessionState,
     @transient private val storeCoordinator: Option[StateStoreCoordinatorRef],
     useColumnFamilies: Boolean = false,
-    extraOptions: Map[String, String] = Map.empty)
+    extraOptions: Map[String, String] = Map.empty,
+    useStatefulProcessorEncoder: Boolean = false)
   extends BaseStateStoreRDD[T, U](dataRDD, checkpointLocation, queryRunId, operatorId,
     sessionState, storeCoordinator, extraOptions) {
 
@@ -125,7 +126,7 @@ class StateStoreRDD[T: ClassTag, U: ClassTag](
     val inputIter = dataRDD.iterator(partition, ctxt)
     val store = StateStore.get(
       storeProviderId, keySchema, valueSchema, numColsPrefixKey, storeVersion,
-      useColumnFamilies, storeConf, hadoopConfBroadcast.value.value)
+      useColumnFamilies, storeConf, hadoopConfBroadcast.value.value, useStatefulProcessorEncoder)
     storeUpdateFunction(store, inputIter)
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/streaming/state/package.scala
@@ -57,7 +57,9 @@ package object state {
         sessionState: SessionState,
         storeCoordinator: Option[StateStoreCoordinatorRef],
         useColumnFamilies: Boolean = false,
-        extraOptions: Map[String, String] = Map.empty)(
+        extraOptions: Map[String, String] = Map.empty,
+        // TODO: refactor using the boolean parameter for choosing stateful encoder into a enum
+        useStatefulProcessorEncoder: Boolean = false)(
         storeUpdateFunction: (StateStore, Iterator[T]) => Iterator[U]): StateStoreRDD[T, U] = {
 
       val cleanedF = dataRDD.sparkContext.clean(storeUpdateFunction)
@@ -82,7 +84,8 @@ package object state {
         sessionState,
         storeCoordinator,
         useColumnFamilies,
-        extraOptions)
+        extraOptions,
+        useStatefulProcessorEncoder)
     }
 
     /** Map each partition of an RDD along with data in a [[ReadStateStore]]. */

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
@@ -55,4 +55,12 @@ class MemoryStateStore extends StateStore() {
   override def prefixScan(prefixKey: UnsafeRow, colFamilyName: String): Iterator[UnsafeRowPair] = {
     throw new UnsupportedOperationException("Doesn't support prefix scan!")
   }
+
+  override def merge(key: UnsafeRow, value: UnsafeRow, colFamilyName: String): Unit = {
+    throw new UnsupportedOperationException("store does not support multiple values per key")
+  }
+
+  override def valuesIterator(key: UnsafeRow, colFamilyName: String): Iterator[UnsafeRow] = {
+    throw new UnsupportedOperationException("store does not support multiple values per key")
+  }
 }

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/MemoryStateStore.scala
@@ -35,8 +35,16 @@ class MemoryStateStore extends StateStore() {
 
   override def get(key: UnsafeRow, colFamilyName: String): UnsafeRow = map.get(key)
 
+  override def get(key: UnsafeRow, userKey: UnsafeRow, colFamilyName: String): UnsafeRow =
+    {throw new UnsupportedOperationException("store does not support multiple keys get")}
+
   override def put(key: UnsafeRow, newValue: UnsafeRow, colFamilyName: String): Unit =
     map.put(key.copy(), newValue.copy())
+
+  def putWithMultipleKeys(key: UnsafeRow, userKey: UnsafeRow, value: UnsafeRow,
+                          colFamilyName: String = StateStore.DEFAULT_COL_FAMILY_NAME): Unit = {
+    throw new UnsupportedOperationException("store does not support multiple keys put")
+  }
 
   override def remove(key: UnsafeRow, colFamilyName: String): Unit = map.remove(key)
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/execution/streaming/state/StateStoreSuite.scala
@@ -65,7 +65,8 @@ class FakeStateStoreProviderWithMaintenanceError extends StateStoreProvider {
       numColsPrefixKey: Int,
       useColumnFamilies: Boolean,
       storeConfs: StateStoreConf,
-      hadoopConf: Configuration): Unit = {
+      hadoopConf: Configuration,
+      useStatefulProcessorEncoder: Boolean = false): Unit = {
     id = stateStoreId
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/StreamSuite.scala
@@ -1420,7 +1420,8 @@ class TestStateStoreProvider extends StateStoreProvider {
       numColsPrefixKey: Int,
       useColumnFamilies: Boolean,
       storeConfs: StateStoreConf,
-      hadoopConf: Configuration): Unit = {
+      hadoopConf: Configuration,
+      useStatefulProcessorEncoder: Boolean = false): Unit = {
     throw new Exception("Successfully instantiated")
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithListStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithListStateSuite.scala
@@ -1,0 +1,213 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider
+import org.apache.spark.sql.internal.SQLConf
+
+case class InputRow(key: String, action: String, value: String)
+
+class TestListStateProcessor
+  extends StatefulProcessor[String, InputRow, (String, String)] {
+
+  @transient var _processorHandle: StatefulProcessorHandle = _
+  @transient var _listState: ListState[String] = _
+
+  override def init(handle: StatefulProcessorHandle, outputMode: OutputMode): Unit = {
+    _processorHandle = handle
+    _listState = handle.getListState("sessionState")
+  }
+
+  override def handleInputRows(key: String,
+      inputRows: Iterator[InputRow],
+      timerValues: TimerValues): Iterator[(String, String)] = {
+
+    var output = List[(String, String)]()
+
+    for (row <- inputRows) {
+      if (row.action == "emit") {
+        output = (key, row.value) :: output
+      } else if (row.action == "emitAllInState") {
+        _listState.get().foreach(v => {
+          output = (key, v) :: output
+        })
+        _listState.remove()
+      } else if (row.action == "append") {
+        _listState.appendValue(row.value)
+      } else if (row.action == "appendAll") {
+        _listState.appendList(row.value.split(",").toSeq)
+      } else if (row.action == "put") {
+        _listState.put(row.value.split(",").toSeq)
+      } else if (row.action == "remove") {
+        _listState.remove()
+      } else if (row.action == "tryAppendingNull") {
+        _listState.appendValue(null)
+      } else if (row.action == "tryAppendingNullValueInList") {
+        _listState.appendList(List(null))
+      } else if (row.action == "tryAppendingNullList") {
+        _listState.appendList(null)
+      } else if (row.action == "tryPutNullList") {
+        _listState.put(null)
+      } else if (row.action == "tryPuttingNullInList") {
+        _listState.put(List(null))
+      }
+    }
+    output.iterator
+  }
+
+
+  override def close(): Unit = {
+  }
+}
+
+class TransformWithListStateSuite extends StreamTest {
+  import testImplicits._
+
+  test("test appending null value in list state throw exception") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+
+      val inputData = MemoryStream[InputRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestListStateProcessor(),
+          TimeoutMode.noTimeouts(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update()) (
+        AddData(inputData, InputRow("k1", "tryAppendingNull", "")),
+        ExpectFailure[SparkException](e => {
+          assert(e.getMessage.contains("value added to ListState should be non-null"))
+        })
+      )
+    }
+  }
+
+  test("test putting null value in list state throw exception") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+
+      val inputData = MemoryStream[InputRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestListStateProcessor(),
+          TimeoutMode.noTimeouts(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update())(
+        AddData(inputData, InputRow("k1", "tryPuttingNullInList", "")),
+        ExpectFailure[SparkException](e => {
+          assert(e.getMessage.contains("value added to ListState should be non-null"))
+        })
+      )
+    }
+  }
+
+  test("test putting null list in list state throw exception") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+
+      val inputData = MemoryStream[InputRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestListStateProcessor(),
+          TimeoutMode.noTimeouts(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update())(
+        AddData(inputData, InputRow("k1", "tryPutNullList", "")),
+        ExpectFailure[SparkException](e => {
+          assert(e.getMessage.contains("newState list should be non-null"))
+        })
+      )
+    }
+  }
+
+  test("test appending null list in list state throw exception") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+
+      val inputData = MemoryStream[InputRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestListStateProcessor(),
+          TimeoutMode.noTimeouts(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update())(
+        AddData(inputData, InputRow("k1", "tryAppendingNullList", "")),
+        ExpectFailure[SparkException](e => {
+          assert(e.getMessage.contains("newState list should be non-null"))
+        })
+      )
+    }
+  }
+
+  test("test list state correctness") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+
+      val inputData = MemoryStream[InputRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestListStateProcessor(),
+          TimeoutMode.noTimeouts(),
+          OutputMode.Update())
+
+      testStream(result, OutputMode.Update()) (
+        // no interaction test
+        AddData(inputData, InputRow("k1", "emit", "v1")),
+        CheckNewAnswer(("k1", "v1")),
+        // check simple append
+        AddData(inputData, InputRow("k1", "append", "v2")),
+        AddData(inputData, InputRow("k1", "emitAllInState", "")),
+        CheckNewAnswer(("k1", "v2")),
+        // multiple appends are correctly stored and emitted
+        AddData(inputData, InputRow("k2", "append", "v1")),
+        AddData(inputData, InputRow("k1", "append", "v4")),
+        AddData(inputData, InputRow("k2", "append", "v2")),
+        AddData(inputData, InputRow("k1", "emit", "v5")),
+        AddData(inputData, InputRow("k2", "emit", "v3")),
+        CheckNewAnswer(("k1", "v5"), ("k2", "v3")),
+        AddData(inputData, InputRow("k1", "emitAllInState", "")),
+        AddData(inputData, InputRow("k2", "emitAllInState", "")),
+        CheckNewAnswer(("k2", "v1"), ("k2", "v2"), ("k1", "v4")),
+        // check appendAll with append
+        AddData(inputData, InputRow("k3", "appendAll", "v1,v2,v3")),
+        AddData(inputData, InputRow("k3", "emit", "v4")),
+        AddData(inputData, InputRow("k3", "append", "v5")),
+        CheckNewAnswer(("k3", "v4")),
+        AddData(inputData, InputRow("k3", "emitAllInState", "")),
+        CheckNewAnswer(("k3", "v1"), ("k3", "v2"), ("k3", "v3"), ("k3", "v5")),
+        // check removal cleans up all data in state
+        AddData(inputData, InputRow("k4", "append", "v2")),
+        AddData(inputData, InputRow("k4", "appendList", "v3,v4")),
+        AddData(inputData, InputRow("k4", "remove", "")),
+        CheckNewAnswer(),
+        // check put cleans up previous state and adds new state
+        AddData(inputData, InputRow("k5", "appendAll", "v1,v2,v3")),
+        AddData(inputData, InputRow("k5", "append", "v4")),
+        AddData(inputData, InputRow("k5", "put", "v5,v6")),
+        AddData(inputData, InputRow("k5", "emitAllInState", "")),
+        CheckNewAnswer(("k5", "v5"), ("k5", "v6"))
+      )
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithMapStateSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/streaming/TransformWithMapStateSuite.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.streaming
+
+// import org.apache.spark.SparkException
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.execution.streaming.state.RocksDBStateStoreProvider
+import org.apache.spark.sql.internal.SQLConf
+
+case class InputMapRow(key: String, action: String, value: (String, Int))
+
+class TestMapStateProcessor
+  extends StatefulProcessor[String, InputMapRow, (String, String, Int)] {
+
+  @transient var _processorHandle: StatefulProcessorHandle = _
+  @transient var _mapState: MapState[String, Int] = _
+
+  override def init(handle: StatefulProcessorHandle, outputMode: OutputMode): Unit = {
+    _processorHandle = handle
+    _mapState = handle.getMapState("sessionState")
+  }
+
+  override def handleInputRows(key: String,
+                               inputRows: Iterator[InputMapRow],
+                               timerValues: TimerValues): Iterator[(String, String, Int)] = {
+
+    var output = List[(String, String, Int)]()
+
+    for (row <- inputRows) {
+      if (row.action == "emit") {
+        output = (key, row.value._1, row.value._2) :: output
+      } else if (row.action == "getValue") {
+        output = (key, row.value._1, _mapState.getValue(row.value._1)) :: output
+      } else if (row.action == "updateValue") {
+        _mapState.updateValue(row.value._1, row.value._2)
+        output = (key, row.value._1, row.value._2) :: output
+      }
+    }
+    output.iterator
+  }
+
+
+  override def close(): Unit = {
+  }
+}
+
+class TransformWithMapStateSuite extends StreamTest {
+  import testImplicits._
+
+  test("test list state correctness") {
+    withSQLConf(SQLConf.STATE_STORE_PROVIDER_CLASS.key ->
+      classOf[RocksDBStateStoreProvider].getName) {
+      val inputData = MemoryStream[InputMapRow]
+      val result = inputData.toDS()
+        .groupByKey(x => x.key)
+        .transformWithState(new TestMapStateProcessor(),
+          TimeoutMode.noTimeouts(),
+          OutputMode.Append())
+      testStream(result, OutputMode.Append())(
+        AddData(inputData, InputMapRow("k2", "updateValue", ("v1", 10))),
+        AddData(inputData, InputMapRow("k2", "updateValue", ("v2", 3))),
+        AddData(inputData, InputMapRow("k2", "updateValue", ("v2", 12))),
+        // AddData(inputData, InputMapRow("k2", "updateValue", ("v4", 1))),
+        CheckAnswer(("k2", "v1", 10), ("k2", "v2", 3), ("k2", "v2", 12)),
+        AddData(inputData, InputMapRow("k2", "getValue", ("v2", 12))),
+        CheckNewAnswer(("k2", "v2", 12))
+      )
+
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This draft PR is for reproducing an error where `StateStore.iterator()` returns empty iterator only. The real implementation of `MapState` will be in a separate PR.